### PR TITLE
Include cascoda-api as submodule and update makefile and readme to match

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cascoda-api"]
+	path = cascoda-api
+	url = https://github.com/Cascoda/cascoda-api.git

--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 Glue code for linking Cascoda's API code to the ca8210 driver module
 
 The `kernel_exchange_init()` function must be called by your application to link the cascoda-api functions to this code.
+
+In order to build a useable library for the ca8210 after cloning the repository, run the commands:
+```
+git submodule update --init
+make
+```
+Then include kernel_exchange.h and cascoda-api/include/cascoda_api.h in your C source, and link with the libca8210.a library.

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -38,9 +38,9 @@
 
 /******************************************************************************/
 
-#define DebugFSMount            ("/sys/kernel/debug")
-#define DriverNode              ("/ca8210")
-#define DriverFilePath          (DebugFSMount DriverNode)
+#define DebugFSMount            "/sys/kernel/debug"
+#define DriverNode              "/ca8210"
+#define DriverFilePath 			(DebugFSMount DriverNode)
 
 /******************************************************************************/
 

--- a/makefile
+++ b/makefile
@@ -20,7 +20,9 @@ HEADERS = $(wildcard $(INCLUDEDIR),*.h)
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
 $(TARGET): $(OBJECTS)
-	ar rcs $(TARGET) $^
+	cp cascoda-api/libcascoda.a ./libcascoda.a
+	ar -x libcascoda.a
+	ar rcs $(TARGET) *.o
 
 clean:
 	-rm -f $(SOURCEDIR)*.o

--- a/makefile
+++ b/makefile
@@ -1,0 +1,32 @@
+TARGET = libca8210.a
+LIBS = -lm
+CC = gcc
+CFLAGS = -g -Wall -pthread
+INCLUDEDIR = cascoda-api/include/
+SOURCEDIR = ./
+SUBDIRS = cascoda-api
+
+.PHONY: default all clean subdirs $(SUBDIRS)
+
+default: $(TARGET)
+all: default
+
+OBJECTS = $(patsubst %.c, %.o, $(wildcard $(SOURCEDIR)*.c))
+HEADERS = $(wildcard $(INCLUDEDIR),*.h)
+
+%.o: %.c $(HEADERS) subdirs
+	$(CC) $(CFLAGS) -c $< -o $@ -I $(INCLUDEDIR)
+
+.PRECIOUS: $(TARGET) $(OBJECTS)
+
+$(TARGET): $(OBJECTS)
+	ar rcs $(TARGET) $^
+
+clean:
+	-rm -f $(SOURCEDIR)*.o
+	-rm -f $(TARGET)
+
+subdirs: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@


### PR DESCRIPTION
The cascoda-api is required in order to use the kernel exchange, and including it as a submodule allows easier intergration into projects with only a single library to link.
