### PR TITLE
Include cascoda-api as submodule and update makefile and readme to match

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cascoda-api"]
+	path = cascoda-api
+	url = https://github.com/Cascoda/cascoda-api.git

--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 Glue code for linking Cascoda's API code to the ca8210 driver module
 
 The `kernel_exchange_init()` function must be called by your application to link the cascoda-api functions to this code.
+
+In order to build a useable library for the ca8210 after cloning the repository, run the commands:
+```
+git submodule update --init
+make
+```
+Then include kernel_exchange.h and cascoda-api/include/cascoda_api.h in your C source, and link with the libca8210.a library.

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -56,6 +56,8 @@ static int ca8210_test_int_exchange(
 static int DriverFileDescriptor;
 static pthread_t rx_thread;
 static pthread_mutex_t rx_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t unhandled_sync_cond = PTHREAD_COND_INITIALIZER;
+static int unhandled_sync_count = 0;
 
 /******************************************************************************/
 
@@ -67,7 +69,15 @@ static void *ca8210_test_int_read_worker(void *arg)
 	while (1) {
 		pthread_mutex_lock(&rx_mutex);
 		rx_len = read(DriverFileDescriptor, rx_buf, 0);
+
+		if(rx_len > 0 && (buf[0] & SPI_SYN)){	//Catch unhandled synchronous commands so synchronicity for future commands is not lost
+			unhandled_sync_count--;
+			assert(unhandled_sync_count >= 0);
+			pthread_cond_signal(&unhandled_sync_cond);
+		}
+
 		pthread_mutex_unlock(&rx_mutex);
+
 		if (rx_len > 0) {
 			cascoda_downstream_dispatch(rx_buf, rx_len);
 		}
@@ -79,12 +89,26 @@ static void *ca8210_test_int_read_worker(void *arg)
 int kernel_exchange_init(void)
 {
 	int ret;
+	static uint8_t initialised = 0;
+
+	if(initialised) return 1;
 
 	DriverFileDescriptor = open(DriverFilePath, O_RDWR);
 
 	cascoda_api_downstream = ca8210_test_int_exchange;
 
+	//Empty the receive buffer for clean start
+	size_t rx_len;
+	do{
+		uint8_t scrap[512];
+		rx_len = read(DriverFileDescriptor, scrap, 0);
+	} while (rx_len != 0);
+
+	unhandled_sync_count = 0;
+
 	ret = pthread_create(&rx_thread, NULL, ca8210_test_int_read_worker, NULL);
+
+	if(ret == 0) initialised = 1;
 	return ret;
 }
 
@@ -107,15 +131,31 @@ static int ca8210_test_int_exchange(
 )
 {
 	int status, Rx_Length;
-	uint8_t isSynchronous = ((buf[0] & SPI_SYN) && response);
+	const uint8_t isSynchronous = ((buf[0] & SPI_SYN) && response);
 
-	if(isSynchronous) pthread_mutex_lock(&rx_mutex);	//Enforce synchronous write then read
+	if(isSynchronous){
+		pthread_mutex_lock(&rx_mutex);	//Enforce synchronous write then read
+		while(unhandled_sync_count != 0) {pthread_cond_wait(&unhandled_sync_cond, &rx_mutex);}
+	}
+	else if(buf[0] & SPI_SYN){
+		pthread_mutex_lock(&rx_mutex);
+		unhandled_sync_count++;
+		pthread_mutex_unlock(&rx_mutex);
+	}
 
 	ca8210_test_int_write(buf, len);
 
 	if (isSynchronous) {
 		do {
 			Rx_Length = read(DriverFileDescriptor, response, NULL);
+
+			if(Rx_Length > 0 && !(response[0] & SPI_SYN)){
+				//Unexpected asynchronous response
+				//TODO: Perhaps queue this to be handled by the worker thread instead?
+				cascoda_downstream_dispatch(response, Rx_Length);
+				Rx_Length = 0;
+			}
+
 		} while (Rx_Length == 0);
 		pthread_mutex_unlock(&rx_mutex);
 	}

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -33,6 +33,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include "cascoda_api.h"
 

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -38,9 +38,9 @@
 
 /******************************************************************************/
 
-#define DebugFSMount            ("/sys/kernel/debug")
-#define DriverNode              ("/ca8210")
-#define DriverFilePath          (DebugFSMount DriverNode)
+#define DebugFSMount            "/sys/kernel/debug"
+#define DriverNode              "/ca8210"
+#define DriverFilePath 			(DebugFSMount DriverNode)
 
 /******************************************************************************/
 

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -70,7 +70,7 @@ static void *ca8210_test_int_read_worker(void *arg)
 		pthread_mutex_lock(&rx_mutex);
 		rx_len = read(DriverFileDescriptor, rx_buf, 0);
 
-		if(rx_len > 0 && (buf[0] & SPI_SYN)){	//Catch unhandled synchronous commands so synchronicity for future commands is not lost
+		if(rx_len > 0 && (rx_buf[0] & SPI_SYN)){	//Catch unhandled synchronous commands so synchronicity for future commands is not lost
 			unhandled_sync_count--;
 			assert(unhandled_sync_count >= 0);
 			pthread_cond_signal(&unhandled_sync_cond);

--- a/makefile
+++ b/makefile
@@ -20,7 +20,9 @@ HEADERS = $(wildcard $(INCLUDEDIR),*.h)
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
 $(TARGET): $(OBJECTS)
-	ar rcs $(TARGET) $^
+	cp cascoda-api/libcascoda.a ./libcascoda.a
+	ar -x libcascoda.a
+	ar rcs $(TARGET) *.o
 
 clean:
 	-rm -f $(SOURCEDIR)*.o

--- a/makefile
+++ b/makefile
@@ -1,0 +1,32 @@
+TARGET = libca8210.a
+LIBS = -lm
+CC = gcc
+CFLAGS = -g -Wall -pthread
+INCLUDEDIR = cascoda-api/include/
+SOURCEDIR = ./
+SUBDIRS = cascoda-api
+
+.PHONY: default all clean subdirs $(SUBDIRS)
+
+default: $(TARGET)
+all: default
+
+OBJECTS = $(patsubst %.c, %.o, $(wildcard $(SOURCEDIR)*.c))
+HEADERS = $(wildcard $(INCLUDEDIR),*.h)
+
+%.o: %.c $(HEADERS) subdirs
+	$(CC) $(CFLAGS) -c $< -o $@ -I $(INCLUDEDIR)
+
+.PRECIOUS: $(TARGET) $(OBJECTS)
+
+$(TARGET): $(OBJECTS)
+	ar rcs $(TARGET) $^
+
+clean:
+	-rm -f $(SOURCEDIR)*.o
+	-rm -f $(TARGET)
+
+subdirs: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@


### PR DESCRIPTION
The cascoda-api is required in order to use the kernel exchange, and including it as a submodule allows easier intergration into projects with only a single library to link.
