### PR TITLE
Use blocking rather than polling & Optional log file

### DIFF
--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -151,6 +151,8 @@ int kernel_exchange_init_withhandler(kernel_exchange_errorhandler callback)
 
 	DriverFileDescriptor = open(DriverFilePath, O_RDWR);
 	LogFileDescriptor = fopen("exchange.log", "a");
+	fputs("\r\n-------------------NEW SESSION-------------------------",LogFileDescriptor);
+	fflush(LogFileDescriptor);
 
 	cascoda_api_downstream = ca8210_test_int_exchange;
 

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -141,7 +141,6 @@ static void *ca8210_test_int_read_worker(void *arg)
 					fprintf(LogFileDescriptor, " %02x", rx_buf[i]);
 				}
 				fputs("\r\n",LogFileDescriptor);
-				fflush(LogFileDescriptor);
 				pthread_mutex_unlock(&file_mutex);
 			}
 #endif
@@ -184,7 +183,6 @@ int kernel_exchange_init_withhandler(kernel_exchange_errorhandler callback)
 #ifdef USE_LOGFILE
 	LogFileDescriptor = fopen("exchange.log", "a");
 	fputs("\r\n-------------------NEW SESSION-------------------------\r\n",LogFileDescriptor);
-	fflush(LogFileDescriptor);
 #endif
 	DriverFileDescriptor = open(DriverFilePath, O_RDWR | O_NONBLOCK);
 
@@ -251,7 +249,6 @@ static int ca8210_test_int_write(const uint8_t *buf, size_t len)
 		fprintf(LogFileDescriptor, " %02x", buf[i]);
 	}
 	fputs("\r\n",LogFileDescriptor);
-	fflush(LogFileDescriptor);
 	pthread_mutex_unlock(&file_mutex);
 #endif
 
@@ -310,7 +307,6 @@ static int ca8210_test_int_exchange(
 					fprintf(LogFileDescriptor, " %02x", response[i]);
 				}
 				fputs("\r\n",LogFileDescriptor);
-				fflush(LogFileDescriptor);
 				pthread_mutex_unlock(&file_mutex);
 			}
 #endif

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -123,10 +123,10 @@ static void *ca8210_test_int_read_worker(void *arg)
 		rx_len = 0;
 
 		//Wait until there is data available to read (or time out after 5 seconds)
-		int numActive = select(DriverFileDescriptor + 1, &rx_block_fd_set, NULL, NULL, &timeout);
+		select(DriverFileDescriptor + 1, &rx_block_fd_set, NULL, NULL, &timeout);
 
 		//try to get fresh data
-		if(numActive != 0 && pthread_mutex_trylock(&rx_mutex) == 0){
+		if(pthread_mutex_trylock(&rx_mutex) == 0){
 			rx_len = read(DriverFileDescriptor, rx_buf, 0);
 
 #ifdef USE_LOGFILE

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -122,6 +122,9 @@ static void *ca8210_test_int_read_worker(void *arg)
 
 		rx_len = 0;
 
+		FD_ZERO(&rx_block_fd_set);
+		FD_SET(DriverFileDescriptor, &rx_block_fd_set);
+
 		//Wait until there is data available to read (or time out after 5 seconds)
 		select(DriverFileDescriptor + 1, &rx_block_fd_set, NULL, NULL, &timeout);
 
@@ -190,9 +193,6 @@ int kernel_exchange_init_withhandler(kernel_exchange_errorhandler callback)
 			errno);
 		return -1;
 	}
-
-	FD_ZERO(&rx_block_fd_set);
-	FD_SET(DriverFileDescriptor, &rx_block_fd_set);
 
 	cascoda_api_downstream = ca8210_test_int_exchange;
 

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -170,7 +170,7 @@ static int ca8210_test_int_write(const uint8_t *buf, size_t len)
 			//TODO: pass the error code to a callback of some sort so the end application can handle gracefully?
 			int error = errno;
 
-			if(errno == EBUSY){	//If the error is that the device is busy, try again after a short wait
+			if(errno == EBUSY || errno == EAGAIN){	//If the error is that the device is busy, try again after a short wait
 				if(attempts++ < 5){
 					struct timespec toSleep;
 					toSleep.tv_sec = 0;

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -126,7 +126,8 @@ static void *ca8210_test_int_read_worker(void *arg)
 		FD_SET(DriverFileDescriptor, &rx_block_fd_set);
 
 		//Wait until there is data available to read (or time out after 5 seconds)
-		select(DriverFileDescriptor + 1, &rx_block_fd_set, NULL, NULL, &timeout);
+		int rval = select(DriverFileDescriptor + 1, &rx_block_fd_set, NULL, NULL, &timeout);
+		assert(rval >= 0);
 
 		//try to get fresh data
 		if(pthread_mutex_trylock(&rx_mutex) == 0){

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -38,7 +38,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <time.h>
+#include <sys/time.h>
 
 #include "cascoda_api.h"
 #include "kernel_exchange.h"
@@ -268,7 +268,7 @@ static int ca8210_test_int_exchange(
 
 	if (isSynchronous) {
 		do {
-			Rx_Length = read(DriverFileDescriptor, response, NULL);
+			Rx_Length = read(DriverFileDescriptor, response, (size_t) 0);
 
 			if (Rx_Length > 0) {
 				pthread_mutex_lock(&file_mutex);

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -150,7 +150,7 @@ int kernel_exchange_init_withhandler(kernel_exchange_errorhandler callback)
 	errorcallback = callback;
 
 	DriverFileDescriptor = open(DriverFilePath, O_RDWR);
-	LogFileDescriptor = open("exchange.log", O_RDWR);
+	LogFileDescriptor = fopen("exchange.log", "a");
 
 	cascoda_api_downstream = ca8210_test_int_exchange;
 

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -127,7 +127,6 @@ static void *ca8210_test_int_read_worker(void *arg)
 
 		//Wait until there is data available to read (or time out after 5 seconds)
 		int rval = select(DriverFileDescriptor + 1, &rx_block_fd_set, NULL, NULL, &timeout);
-		assert(rval >= 0);
 
 		//try to get fresh data
 		if(pthread_mutex_trylock(&rx_mutex) == 0){

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -60,7 +60,7 @@ static int ca8210_test_int_exchange(
 /******************************************************************************/
 
 static int DriverFileDescriptor;
-static int LogFileDescriptor;
+static FILE * LogFileDescriptor;
 static pthread_t rx_thread;
 static pthread_mutex_t rx_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t tx_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -203,8 +203,8 @@ static int ca8210_test_int_write(const uint8_t *buf, size_t len)
 
 	pthread_mutex_lock(&file_mutex);
 	fputs("\r\nWriting data:  ",LogFileDescriptor);
-	for(i = 0; i < rx_len; i++){
-		fprintf(LogFileDescriptor, " %02x", rx_buf[i]);
+	for(i = 0; i < len; i++){
+		fprintf(LogFileDescriptor, " %02x", buf[i]);
 	}
 	fputs("\r\n",LogFileDescriptor);
 	fflush(LogFileDescriptor);
@@ -221,7 +221,7 @@ static int ca8210_test_int_exchange(
 	void *pDeviceRef
 )
 {
-	int Rx_Length, error;
+	int Rx_Length, error, i;
 	const uint8_t isSynchronous = ((buf[0] & SPI_SYN) && response);
 
 	if(isSynchronous){
@@ -256,11 +256,11 @@ static int ca8210_test_int_exchange(
 		do {
 			Rx_Length = read(DriverFileDescriptor, response, NULL);
 
-			if (rx_len > 0) {
+			if (Rx_Length > 0) {
 				pthread_mutex_lock(&file_mutex);
 				fputs("\r\nReceived  Sync:",LogFileDescriptor);
-				for(i = 0; i < rx_len; i++){
-					fprintf(LogFileDescriptor, " %02x", rx_buf[i]);
+				for(i = 0; i < Rx_Length; i++){
+					fprintf(LogFileDescriptor, " %02x", response[i]);
 				}
 				fputs("\r\n",LogFileDescriptor);
 				fflush(LogFileDescriptor);

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -126,7 +126,7 @@ static void *ca8210_test_int_read_worker(void *arg)
 		FD_SET(DriverFileDescriptor, &rx_block_fd_set);
 
 		//Wait until there is data available to read (or time out after 5 seconds)
-		int rval = select(DriverFileDescriptor + 1, &rx_block_fd_set, NULL, NULL, &timeout);
+		select(DriverFileDescriptor + 1, &rx_block_fd_set, NULL, NULL, &timeout);
 
 		//try to get fresh data
 		if(pthread_mutex_trylock(&rx_mutex) == 0){

--- a/kernel_exchange.c
+++ b/kernel_exchange.c
@@ -123,7 +123,7 @@ static void *ca8210_test_int_read_worker(void *arg)
 		rx_len = 0;
 
 		//Wait until there is data available to read (or time out after 5 seconds)
-		int numActive = select(DriverFileDescriptor + 1, rx_block_fd_set, NULL, NULL, &timeout);
+		int numActive = select(DriverFileDescriptor + 1, &rx_block_fd_set, NULL, NULL, &timeout);
 
 		//try to get fresh data
 		if(numActive != 0 && pthread_mutex_trylock(&rx_mutex) == 0){
@@ -191,8 +191,8 @@ int kernel_exchange_init_withhandler(kernel_exchange_errorhandler callback)
 		return -1;
 	}
 
-	FD_ZERO(rx_block_fd_set);
-	FD_SET(DriverFileDescriptor, rx_block_fd_set);
+	FD_ZERO(&rx_block_fd_set);
+	FD_SET(DriverFileDescriptor, &rx_block_fd_set);
 
 	cascoda_api_downstream = ca8210_test_int_exchange;
 

--- a/makefile
+++ b/makefile
@@ -1,6 +1,5 @@
 TARGET = libca8210.a
 LIBS = -lm
-CC = gcc
 CFLAGS = -g -Wall -pthread
 INCLUDEDIR = cascoda-api/include/
 SOURCEDIR = ./


### PR DESCRIPTION
The updated features of the ca8210-linux driver means that it is now possible to use a blocking read_worker rather than continuously polling. This hugely reduces CPU usage and also improves reliability.

A log file has also been added which logs all IO at the kernal exchange layer. It can be disabled by removing the definition of USE_LOGFILE.